### PR TITLE
Change the warning query to only catch vulnerabilities

### DIFF
--- a/NuGetVulnerabilityScanner/NuGetVulnerabilityScanner.csproj
+++ b/NuGetVulnerabilityScanner/NuGetVulnerabilityScanner.csproj
@@ -9,7 +9,7 @@
 	<ToolCommandName>NugetScan</ToolCommandName>
 	<PackageOuputPath>./nupkg</PackageOuputPath>
 	<PackageId>VertiGIS.NugetScan</PackageId>
-	<PackageVersion>1.0.5</PackageVersion>
+	<PackageVersion>1.0.7</PackageVersion>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/NuGetVulnerabilityScanner/Program.cs
+++ b/NuGetVulnerabilityScanner/Program.cs
@@ -14,7 +14,7 @@ class Program
         string restoreOutputPath = Path.Combine(workingDir, "restore_output.txt");
 
         List<string> restoreWarnings = File.ReadAllLines(restoreOutputPath)
-                                            .Where(line => line.IndexOf("warning", StringComparison.OrdinalIgnoreCase) >= 0)
+                                            .Where(line => line.IndexOf("NU1903", StringComparison.OrdinalIgnoreCase) >= 0 || line.IndexOf("NU1904", StringComparison.OrdinalIgnoreCase) >= 0)
                                             .ToList();
         List<string> validatedWarnings = new List<string>();
 


### PR DESCRIPTION
Found a shortcoming of the script where certain warnings were being caught that were not related to code vulnerabilities that would break the build, the adjustment here ensures we are only catching valid vulnerability warnings